### PR TITLE
Broken binary is generated when empty array passed

### DIFF
--- a/generator/array.go
+++ b/generator/array.go
@@ -7,7 +7,7 @@ import (
 const arraySerializerTemplate = `
 func %v(r %v, w io.Writer) error {
 	err := writeLong(int64(len(r)),w)
-	if err != nil {
+	if err != nil || len(r) == 0 {
 		return err
 	}
 	for _, e := range r {

--- a/test/arrays/schema_test.go
+++ b/test/arrays/schema_test.go
@@ -14,6 +14,7 @@ import (
 const fixtureJson = `
 [
 {"IntField": [1, -2147483647, 2147483647], "LongField": [2, 9223372036854775807, -9223372036854775807], "FloatField": [3.4, 3.402823e-38, 3.402823e+38], "DoubleField": [ 5.6, 2.2250738585072014e-308], "StringField": ["short", "789", "longer", "a slightly longer string"], "BoolField": [true, false], "BytesField": ["VGhpcyBpcyBhIHRlc3Qgc3RyaW5n"]},
+{"IntField":[], "LongField": [2], "FloatField": [], "DoubleField": [5.6], "StringField": [], "BoolField": [true], "BytesField": []},
 {"IntField":[], "LongField": [], "FloatField": [], "DoubleField": [], "StringField": [], "BoolField": [], "BytesField": []}
 ]
 `


### PR DESCRIPTION
When the message containing zero-length arrays passed, it will be serialized to invalid binary that we cannot deserialize correctly.
