### PR TITLE
Proposal to update ToPublicName to be go-idiomatic

### DIFF
--- a/generator/util.go
+++ b/generator/util.go
@@ -2,15 +2,14 @@ package generator
 
 import (
 	"sort"
-	"strings"
 	"unicode"
+
+	"github.com/serenize/snaker"
 )
 
+// ToPublicName returns a go-idiomatic public name
 func ToPublicName(name string) string {
-	if name == "" {
-		return ""
-	}
-	return strings.ToUpper(name[0:1]) + name[1:]
+	return snaker.SnakeToCamel(name)
 }
 
 func concatSortedMap(m map[string]string, sep string) string {


### PR DESCRIPTION
Proposed change to generated Struct/Field names.
The names become CamelCase and abbreviations are fully capitalized.

#### Examples
* `full_name`-> `FullName`
* `person_id` -> `PersonID`
* `url` -> `URL`

The dependency on `snaker` can be removed, if desired, as the code can be copied over and is fairly short.