### PR TITLE
Make generated code package name a flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ go get gopkg.in/alanctgardner/gogen-avro.v2/...
 To generate Go source files from one or more Avro schema files, run:
 
 ```
-gogen-avro [--container] <output directory> <avro schema files>
+gogen-avro [--container] [--package=<package name>] <output directory> <avro schema files>
 ```
 
 You can also use a `go:generate` directive in a source file ([example](https://github.com/alanctgardner/gogen-avro/blob/master/test/primitive/schema_test.go)):
@@ -37,7 +37,7 @@ _Container file support is still being worked on - please report any bugs you fi
 
 Supplying the `--container` flag generates a container file writer for each schema in addition to the serializers.
 
-The container file writer should be constructed with an existing `io.Writer`, a `Codec` (`Null`, `Snappy`, or `Deflate`) and a block size in records. Records are encoded and buffered when you call `writer.writeRecord(record)`, and synchronously flushed when the block size is hit. You can also manually flush a block by calling `writer.Flush()`. You must call `writer.Flush()` before closing the underlying `io.Writer`, to ensure all the records in the last block are written. 
+The container file writer should be constructed with an existing `io.Writer`, a `Codec` (`Null`, `Snappy`, or `Deflate`) and a block size in records. Records are encoded and buffered when you call `writer.writeRecord(record)`, and synchronously flushed when the block size is hit. You can also manually flush a block by calling `writer.Flush()`. You must call `writer.Flush()` before closing the underlying `io.Writer`, to ensure all the records in the last block are written.
 
 An example of how to write a container file can be found in `example/container/example.go`.
 
@@ -46,7 +46,7 @@ An example of how to write a container file can be found in `example/container/e
 The `example` directory contains simple example projects with an Avro schema. Once you've installed gogen-avro on your GOPATH, you can install the example projects:
 
 ```
-# Build the Go source files from the Avro schema using the generate directive 
+# Build the Go source files from the Avro schema using the generate directive
 go generate github.com/alanctgardner/gogen-avro/example
 
 # Install the example projects on the gopath
@@ -89,7 +89,7 @@ const (
 	UnionNullIntTypeEnumNull            UnionNullIntTypeEnum = 0
 	UnionNullIntTypeEnumInt             UnionNullIntTypeEnum = 1
 )
-``` 
+```
 
 ### TODO / Caveats
 

--- a/main.go
+++ b/main.go
@@ -3,25 +3,27 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"os"
+
 	"github.com/alanctgardner/gogen-avro/container"
 	"github.com/alanctgardner/gogen-avro/generator"
 	"github.com/alanctgardner/gogen-avro/types"
-	"io/ioutil"
-	"os"
 )
 
 func main() {
 	generateContainer := flag.Bool("container", false, "Whether to emit container file writer code")
+	packageName := flag.String("package", "avro", "Name of generated package")
 	flag.Parse()
 	if flag.NArg() < 2 {
-		fmt.Fprintf(os.Stderr, "Usage: gogen-avro [--container] <target directory> <schema files>\n")
+		fmt.Fprintf(os.Stderr, "Usage: gogen-avro [--container] [--package=<package name>] <target directory> <schema files>\n")
 		os.Exit(1)
 	}
 	targetDir := flag.Arg(0)
 	files := flag.Args()[1:]
 
 	var err error
-	pkg := generator.NewPackage("avro")
+	pkg := generator.NewPackage(*packageName)
 
 	if *generateContainer {
 		err = addRecordDefinition([]byte(container.AVRO_BLOCK_SCHEMA), pkg, false)


### PR DESCRIPTION
It would be nice to be able to specify the package name of the generated code, particularly if you'd like to generate code for multiple schemas into different sub-packages in the same project.