### PR TITLE
Fix sources header to only show file names

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/alanctgardner/gogen-avro/generator"
@@ -91,7 +92,8 @@ func codegenComment(sources []string) string {
 	}
 
 	for _, source := range sources {
-		sourceBlock = append(sourceBlock, fmt.Sprintf(" *     %s", source))
+		_, fName := filepath.Split(source)
+		sourceBlock = append(sourceBlock, fmt.Sprintf(" *     %s", fName))
 	}
 
 	return fmt.Sprintf(fileComment, strings.Join(sourceBlock, "\n"))


### PR DESCRIPTION
This is kind of a minor thing but currently the header will include a file path for the source files, which is meaningless in most cases (e.g. `./workspace/schemas/my_schema.avsc`)

This is a proposal to strip this path to just a file name.