### PR TITLE
Fix map not creating structs for records

### DIFF
--- a/types/map.go
+++ b/types/map.go
@@ -99,7 +99,9 @@ func (s *mapField) DeserializerMethod() string {
 	return fmt.Sprintf("read%v", s.FieldType())
 }
 
-func (s *mapField) AddStruct(p *generator.Package) {}
+func (s *mapField) AddStruct(p *generator.Package) {
+	s.itemType.AddStruct(p)
+}
 
 func (s *mapField) AddSerializer(p *generator.Package) {
 	s.itemType.AddSerializer(p)


### PR DESCRIPTION
Hey,

Seemed that map was missing a call to `s.itemType.AddStruct`.

Should fix #23 