### PR TITLE
Support complex string field type containing "avro.java.string"

### DIFF
--- a/test/avro_java_string/avro_java_string.avsc
+++ b/test/avro_java_string/avro_java_string.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "event",
+  "subject": "event",
+  "fields": [
+    {
+      "name": "id",
+      "type": {
+        "type": "string",
+        "avro.java.string": "String"
+      },
+      "doc": "Unique ID for this event."
+    }
+  ]
+}
+

--- a/test/avro_java_string/container_test.go
+++ b/test/avro_java_string/container_test.go
@@ -1,0 +1,58 @@
+package avro
+
+import (
+	"testing"
+	"bytes"
+	"github.com/linkedin/goavro"
+	"github.com/alanctgardner/gogen-avro/container"
+)
+
+func TestNullEncoding(t *testing.T) {
+	roundTripWithCodec(container.Null, t)
+}
+
+func TestSnappyEncoding(t *testing.T) {
+	roundTripWithCodec(container.Deflate, t)
+}
+
+func TestDeflateEncoding(t *testing.T) {
+	roundTripWithCodec(container.Snappy, t)
+}
+
+func roundTripWithCodec(codec container.Codec, t *testing.T) {
+	var buf bytes.Buffer
+	// Write the container file contents to the buffer
+	containerWriter, err := container.NewWriter(&buf, codec, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, f := range fixtures {
+		// Write the record to the container file
+		err = containerWriter.WriteRecord(&f)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Flush the buffers to ensure the last block has been written
+	err = containerWriter.Flush()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := goavro.NewReader(goavro.FromReader(&buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var i int
+	for reader.Scan() {
+		datum, err := reader.Read()
+		if err != nil {
+			t.Fatal(err)
+		}
+		compareFixtureGoAvro(t, datum, fixtures[i])
+		i = i + 1
+	}
+}

--- a/test/avro_java_string/generate.go
+++ b/test/avro_java_string/generate.go
@@ -1,0 +1,3 @@
+package avro
+
+//go:generate $GOPATH/bin/gogen-avro . avro_java_string.avsc

--- a/test/avro_java_string/schema_test.go
+++ b/test/avro_java_string/schema_test.go
@@ -1,0 +1,62 @@
+package avro
+
+import (
+	"bytes"
+	"github.com/linkedin/goavro"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+/* Round-trip some primitive values through our serializer and goavro to verify */
+var fixtures = []Event{
+	{
+		ID:      "id1",
+	},
+	{
+		ID:      "differentid",
+	},
+}
+
+func compareFixtureGoAvro(t *testing.T, actual interface{}, expected interface{}) {
+	record := actual.(*goavro.Record)
+	fixture := expected.(Event)
+	id, err := record.Get("id")
+	assert.Nil(t, err)
+	assert.Equal(t, id, fixture.ID)
+}
+
+func TestRootUnionFixture(t *testing.T) {
+	codec, err := goavro.NewCodec(fixtures[0].Schema())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	for _, f := range fixtures {
+		buf.Reset()
+		err = writeEvent(&f, &buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		datum, err := codec.Decode(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		compareFixtureGoAvro(t, datum, f)
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	for _, f := range fixtures {
+		buf.Reset()
+		err := writeEvent(&f, &buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		datum, err := readEvent(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, datum, &f)
+	}
+}

--- a/types/schema.go
+++ b/types/schema.go
@@ -294,6 +294,20 @@ func (n *Namespace) decodeComplexDefinition(namespace, nameStr string, typeMap m
 		return nil, NewSchemaError(nameStr, err)
 	}
 	switch typeStr {
+	case "string":
+		var defStr string
+		var ok bool
+		if hasDef {
+			defStr, ok = def.(string)
+			if !ok {
+				return nil, fmt.Errorf("Default value must be string type")
+			}
+		}
+		return &stringField{
+			name: nameStr,
+			defaultValue: defStr,
+			hasDefault: hasDef,
+		}, nil
 	case "array":
 		items, ok := typeMap["items"]
 		if !ok {


### PR DESCRIPTION
Schemas used to generate Java classes will often define a string field using a complex definition like so:

```
"type": {
   "type": "string",
   "avro.java.string": "String"
}
```

Currently, the generator complains with `Error parsing schema for field ".": Unknown type name string` when encountering these. 

This patch attempts to add support for this.