### PR TITLE
Allow to pass in schema when creating a container writer

### DIFF
--- a/container/writer.go
+++ b/container/writer.go
@@ -38,15 +38,16 @@ type Writer struct {
 	blockBuffer      *bytes.Buffer
 	compressedWriter io.Writer
 	nextBlockRecords int64
-	headerWritten    bool
 }
 
 /*
   Create a new Writer wrapping the provided io.Writer with the given Codec and number of records per block.
   The Writer will lazily write the container file header when WriteRecord is called the first time.
   You must call Flush on the Writer before closing the underlying io.Writer, to ensure the final block is written.
+  A schema string must be passed to ensure that a correct header is written even if no records are written. This
+  is required to produce valid empty Avro container files.
 */
-func NewWriter(writer io.Writer, codec Codec, recordsPerBlock int64) (*Writer, error) {
+func NewWriter(writer io.Writer, codec Codec, recordsPerBlock int64, schema string) (*Writer, error) {
 	blockBytes := make([]byte, 0)
 	blockBuffer := bytes.NewBuffer(blockBytes)
 
@@ -56,7 +57,6 @@ func NewWriter(writer io.Writer, codec Codec, recordsPerBlock int64) (*Writer, e
 		codec:           codec,
 		recordsPerBlock: recordsPerBlock,
 		blockBuffer:     blockBuffer,
-		headerWritten:   false,
 	}
 	var err error
 	if codec == Deflate {
@@ -68,6 +68,11 @@ func NewWriter(writer io.Writer, codec Codec, recordsPerBlock int64) (*Writer, e
 		avroWriter.compressedWriter = newSnappyWriter(avroWriter.blockBuffer)
 	} else if codec == Null {
 		avroWriter.compressedWriter = avroWriter.blockBuffer
+	}
+
+	err = avroWriter.writeHeader(schema)
+	if err != nil {
+		return nil, err
 	}
 
 	return avroWriter, nil
@@ -92,14 +97,6 @@ func (avroWriter *Writer) writeHeader(schema string) error {
 */
 func (avroWriter *Writer) WriteRecord(record AvroRecord) error {
 	var err error
-	// Lazily write the header when the first record is written
-	if !avroWriter.headerWritten {
-		avroWriter.headerWritten = true
-		err = avroWriter.writeHeader(record.Schema())
-		if err != nil {
-			return err
-		}
-	}
 	// Serialize the new record into the compressed writer
 	err = record.Serialize(avroWriter.compressedWriter)
 	if err != nil {
@@ -121,11 +118,6 @@ func (avroWriter *Writer) WriteRecord(record AvroRecord) error {
   This must be called before the underlying io.Writer is closed.
 */
 func (avroWriter *Writer) Flush() error {
-	// Don't flush if unused
-	if !avroWriter.headerWritten {
-		return nil
-	}
-
 	// Write out all of the buffered records as a new block
 	// Must be called before closing to ensure the last block is written
 	if fwWriter, ok := avroWriter.compressedWriter.(CloseableResettableWriter); ok {

--- a/example/container/example.go
+++ b/example/container/example.go
@@ -28,7 +28,7 @@ func main() {
 	// Create a container.Writer which can write any generated Avro struct to a file
 	// Note that all the objects written to the file must be the same type
 	// Using the Null codec means blocks are uncompressed - other options are Snappy and Deflate
-	containerWriter, err := container.NewWriter(fileWriter, container.Null, 10)
+	containerWriter, err := container.NewWriter(fileWriter, container.Null, 10, demoStruct.Schema())
 	if err != nil {
 		fmt.Printf("Error opening container writer: %v\n", err)
 		return

--- a/test/alias-fixed/container_test.go
+++ b/test/alias-fixed/container_test.go
@@ -24,7 +24,8 @@ func TestDeflateEncoding(t *testing.T) {
 func roundTripWithCodec(codec container.Codec, t *testing.T) {
 	var buf bytes.Buffer
 	// Write the container file contents to the buffer
-	containerWriter, err := container.NewWriter(&buf, codec, 2)
+	sampleEvent := Event{}
+	containerWriter, err := container.NewWriter(&buf, codec, 2, sampleEvent.Schema())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/avro-java-string/container_test.go
+++ b/test/avro-java-string/container_test.go
@@ -22,7 +22,8 @@ func TestDeflateEncoding(t *testing.T) {
 func roundTripWithCodec(codec container.Codec, t *testing.T) {
 	var buf bytes.Buffer
 	// Write the container file contents to the buffer
-	containerWriter, err := container.NewWriter(&buf, codec, 2)
+	sampleEvent := Event{}
+	containerWriter, err := container.NewWriter(&buf, codec, 2, sampleEvent.Schema())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/primitive/container_test.go
+++ b/test/primitive/container_test.go
@@ -32,7 +32,8 @@ func roundTripWithCodec(codec container.Codec, t *testing.T) {
 	var buf bytes.Buffer
 	// Write the container file contents to the buffer
 	var containerWriter *container.Writer
-	containerWriter, err = container.NewWriter(&buf, codec, 2)
+	sampleRecord := PrimitiveTestRecord{}
+	containerWriter, err = container.NewWriter(&buf, codec, 2, sampleRecord.Schema())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/union-root/container_test.go
+++ b/test/union-root/container_test.go
@@ -60,7 +60,8 @@ func TestIPSchemaMetadata(t *testing.T) {
 func roundTripWithCodec(codec container.Codec, t *testing.T) {
 	var buf bytes.Buffer
 	// Write the container file contents to the buffer
-	containerWriter, err := container.NewWriter(&buf, codec, 2)
+	sampleEvent := Event{}
+	containerWriter, err := container.NewWriter(&buf, codec, 2, sampleEvent.Schema())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Currently, the container writer produces invalid Avro container files when no records are written. If `Flush` is not called, file is empty. If `Flush` is called, an empty block is written without a header before. In both case, the resulting files are not valid Avro container files.

This small modification allows to pass in a schema when creating the writer, to avoid writing the header lazily. This allows to write valid container files when no records get written.