### PR TITLE
Limit panic on large or corrupted string length

### DIFF
--- a/test/string/generate.go
+++ b/test/string/generate.go
@@ -1,0 +1,3 @@
+package avro
+
+//go:generate $GOPATH/bin/gogen-avro --containers . stringtest.avsc

--- a/test/string/schema_test.go
+++ b/test/string/schema_test.go
@@ -1,0 +1,72 @@
+package avro
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+)
+
+var testCases = []struct {
+	input         StringRec
+	length        int64
+	expectFailure bool
+}{
+	{StringRec{"Test string"}, 0, false},
+	{StringRec{"Test string"}, math.MaxInt64, true},
+}
+
+// Test string deserializer behaviour to check that corrupted string will not generate a panic.
+func TestCorruptString(t *testing.T) {
+	for _, testCase := range testCases {
+		var length int64 = testCase.length
+
+		// If length is 0, calculate actual string length, otherwise take test value to "corrupt" it.
+		if testCase.length == 0 {
+			length = int64(len(testCase.input.ProductName))
+		}
+
+		buffer, err := prepareBuffer(length, testCase.input)
+		if err != nil {
+			t.Error("cannot prepare buffer:", err)
+		}
+
+		output, err := DeserializeStringRec(&buffer)
+		if err != nil {
+			if !testCase.expectFailure {
+				t.Error("deserialize failed:", err)
+			}
+			return
+		}
+
+		if testCase.expectFailure {
+			t.Error("expecting error on deserialize")
+			return
+		}
+
+		checkEqual(testCase.input, output, t)
+	}
+}
+
+// Manually prepare simple Avro string buffer to generate possibly corrupted string.
+func prepareBuffer(length int64, input StringRec) (bytes.Buffer, error) {
+	var buffer bytes.Buffer
+
+	err := writeLong(length, &buffer)
+	if err != nil {
+		return buffer, errors.New("cannot generate string length")
+	}
+
+	_, err = buffer.Write([]byte(input.ProductName))
+	if err != nil {
+		return buffer, errors.New("cannot append string")
+	}
+	return buffer, nil
+}
+
+func checkEqual(input StringRec, output *StringRec, t *testing.T) {
+	if !reflect.DeepEqual(input, *output) {
+		t.Error("deserialized content not equal to input")
+	}
+}

--- a/test/string/schema_test.go
+++ b/test/string/schema_test.go
@@ -15,6 +15,7 @@ var testCases = []struct {
 }{
 	{StringRec{"Test string"}, 0, false},
 	{StringRec{"Test string"}, math.MaxInt64, true},
+	{StringRec{"Test string"}, -1, true},
 }
 
 // Test string deserializer behaviour to check that corrupted string will not generate a panic.
@@ -37,12 +38,12 @@ func TestCorruptString(t *testing.T) {
 			if !testCase.expectFailure {
 				t.Error("deserialize failed:", err)
 			}
-			return
+			continue
 		}
 
 		if testCase.expectFailure {
 			t.Error("expecting error on deserialize")
-			return
+			continue
 		}
 
 		checkEqual(testCase.input, output, t)

--- a/test/string/stringtest.avsc
+++ b/test/string/stringtest.avsc
@@ -1,0 +1,10 @@
+{
+  "name" : "StringRec",
+  "type" : "record",
+  "fields" : [
+    {
+      "name" : "productName",
+      "type" : "string"
+    }
+  ]
+}

--- a/types/map.go
+++ b/types/map.go
@@ -116,6 +116,8 @@ func (s *mapField) AddDeserializer(p *generator.Package) {
 	p.AddFunction(UTIL_FILE, "", "readString", readStringMethod)
 	p.AddFunction(UTIL_FILE, "", methodName, mapDeserializer)
 	p.AddImport(UTIL_FILE, "io")
+	p.AddImport(UTIL_FILE, "fmt")
+	p.AddImport(UTIL_FILE, "math")
 }
 
 func (s *mapField) ResolveReferences(n *Namespace) error {

--- a/types/string.go
+++ b/types/string.go
@@ -32,6 +32,13 @@ func readString(r io.Reader) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+  // makeslice can fail depending on available memory.
+  // We arbitrarily limit string size to sane default (~2.2GB).
+	if len > math.MaxInt32 {
+		return "", fmt.Errorf("input string length too large: %d", len)
+	}
+
 	bb := make([]byte, len)
 	_, err = io.ReadFull(r, bb)
 	if err != nil {
@@ -68,6 +75,8 @@ func (s *stringField) AddDeserializer(p *generator.Package) {
 	p.AddFunction(UTIL_FILE, "", "readLong", readLongMethod)
 	p.AddFunction(UTIL_FILE, "", "readString", readStringMethod)
 	p.AddImport(UTIL_FILE, "io")
+	p.AddImport(UTIL_FILE, "fmt")
+	p.AddImport(UTIL_FILE, "math")
 }
 
 func (s *stringField) DefaultValue(lvalue string, rvalue interface{}) (string, error) {

--- a/types/string.go
+++ b/types/string.go
@@ -35,8 +35,8 @@ func readString(r io.Reader) (string, error) {
 
   // makeslice can fail depending on available memory.
   // We arbitrarily limit string size to sane default (~2.2GB).
-	if len > math.MaxInt32 {
-		return "", fmt.Errorf("input string length too large: %d", len)
+	if len < 0 || len > math.MaxInt32 {
+		return "", fmt.Errorf("string length out of range: %d", len)
 	}
 
 	bb := make([]byte, len)


### PR DESCRIPTION
When we receive a string with a huge length (because it is corrupted or because it is very large), the code will panic.

The panic happens in makeslice Go library: https://golang.org/src/runtime/slice.go

This patch assume that if the string length is negative or larger than MaxInt32, something is wrong and will return an error.

It should protect the library against most panic raised in that situation.

The rational is that panic while processing stream of data can be critical. We should probably ignore the message with the error and try continuing processing next message.

Please, let me know if you have comments or idea to improve the patch.