### PR TITLE
don't write 0 byte normal blocks

### DIFF
--- a/container/writer.go
+++ b/container/writer.go
@@ -125,14 +125,16 @@ func (avroWriter *Writer) Flush() error {
 		fwWriter.Reset(avroWriter.blockBuffer)
 	}
 
-	block := &avro.AvroContainerBlock{
-		NumRecords:  avroWriter.nextBlockRecords,
-		RecordBytes: avroWriter.blockBuffer.Bytes(),
-		Sync:        avroWriter.syncMarker,
-	}
-	err := block.Serialize(avroWriter.writer)
-	if err != nil {
-		return err
+	if avroWriter.nextBlockRecords > 0 {
+		block := &avro.AvroContainerBlock{
+			NumRecords:  avroWriter.nextBlockRecords,
+			RecordBytes: avroWriter.blockBuffer.Bytes(),
+			Sync:        avroWriter.syncMarker,
+		}
+		err := block.Serialize(avroWriter.writer)
+		if err != nil {
+			return err
+		}
 	}
 
 	avroWriter.blockBuffer.Reset()


### PR DESCRIPTION
although this appear to be within the avro spec, the apache project
based avro reader for bigquery won't import them properly, failing with
"The Apache Avro library failed to read data with the follwing error:
EOF reached" [sic]. The goavro project example avrw also gives an error
on these files. Both tools are happy with avro files that contain only a
single schema block and no normal blocks.
